### PR TITLE
KM594 🐛 Bump argoCD also when version is 1.6.2

### DIFF
--- a/upgrades/0.0.87.argocd/pkg/argocd/api.go
+++ b/upgrades/0.0.87.argocd/pkg/argocd/api.go
@@ -32,8 +32,7 @@ const (
 	deleteReleaseRetrySeconds            = 3
 	waitForIngressDeletionTimeoutSeconds = 8 * 60
 
-	appVersionBeforeUpgrade = "v1.6.2"
-	appVersionAfterUpgrade  = "v2.1.7"
+	appVersionAfterUpgrade = "v2.1.7"
 )
 
 // ArgoCD is a sample okctl component
@@ -102,13 +101,25 @@ func (a ArgoCD) preflight() error {
 	}
 
 	currentVersion := getHelmReleaseAppVersion(release)
-	if currentVersion != appVersionBeforeUpgrade {
+	appVersionsToUpgrade := []string{"1.6.2", "v1.6.2"}
+
+	if !arrayContains(appVersionsToUpgrade, currentVersion) {
 		a.log.Infof("Current chart version is %s. This upgrade only targets chart version %s. Ignoring upgrade.\n",
-			currentVersion, appVersionBeforeUpgrade)
+			currentVersion, strings.Join(appVersionsToUpgrade, ", "))
 		return errNothingToDo
 	}
 
 	return nil
+}
+
+func arrayContains(arr []string, toFind string) bool {
+	for _, arrItem := range arr {
+		if arrItem == toFind {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (a ArgoCD) partiallyRemoveArgoCD() error {


### PR DESCRIPTION
Not just v1.6.2.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://trello.com/c/Npobai7x/594-argocd-bump-upgrade-doesnt-upgrade-when-version-is-prefixed-with-v

```
--- Running upgrade: okctl-upgrade_0.0.87.argocd ---
Current chart version is 1.6.2. This upgrade only targets chart version v1.6.2. Ignoring upgrade.
```

This is obviously wrong.

## How to prove the effect of this PR?

<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

## Additional info

<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
