### PR TITLE
Set CGO_ENABLED to 1. This will make the keychain work on Mac

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ before:
 # Configuration: https://goreleaser.com/customization/build/
 builds:
   - env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - linux
       - darwin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`okctl-upgrade_0.0.87.argocd` will not execute when running `okctl upgrade`. It will complain that it is `unable to create a keyring. It is possible no valid backends were found`

The problem comes down to CGO_ENABLED in .goreleaser.yaml

# CGO_ENABLED=0
- this is current situation, upgrading with stock okctl and fetching releases from `okctl-upgrade`

```
origo ~/Documents/okctl/h-eide-okctl-config [master] okctl venv -c cluster/h-eide-dev/cluster.yaml
...

~/Documents/okctl/h-eide-okctl-config (h-eide-dev:default) $ okctl upgrade
Found 2 applicable upgrade(s):
0.0.87.argocd, 0.0.88.activate-argo-app-sync

preloading missing binary: okctl-upgrade_0.0.87.argocd (0.0.87.argocd)
preloading missing binary: okctl-upgrade_0.0.88.activate-argo-app-sync (0.0.88.activate-argo-app-sync)
Simulating upgrades (we're not doing any actual changes yet, just printing what's going to happen)...

--- Simulating upgrade: okctl-upgrade_0.0.87.argocd ---
creating argocd: initializing: initializing okctl: acquiring Github authenticator: unable to create a keyring. It is possible no valid backends were found
on your system, take a look at this site for valid options:
https://github.com/99designs/keyring#keyring

On linux pass works well, for instance:
https://www.passwordstore.org/

Specified keyring backend not available
--- Upgrade failed: okctl-upgrade_0.0.87.argocd ---
Error: upgrading: running upgrade binaries: simulating upgrades: running upgrade binary okctl-upgrade_0.0.87.argocd: executing command: /var/folders/56/8f6jsj714x35twp23bvlzx740000gp/T/okctl2112369526/binaries/okctl-upgrade_0.0.87.argocd/0.0.87.argocd/Darwin/amd64/okctl-upgrade_0.0.87.argocd, got: exit status 1
```
The upgrade fails on first upgrade with a error message 


# CGO_ENABLED=1
- see notes on https://github.com/oslokommune/okctl/pull/314
- changed .goreleaser.yaml: CGO_ENABLED=1 
- use: `./test-release 0.0.87+argocd` to push a new release to okctl-upgrade-test repo
- Changed upgrade.go in okctl: `const OkctlUpgradeRepo = "okctl-upgrade-test"` 
- recompiled okctl locally, now pointing to okctl-upgrade-test
- do `okctl venv` with local okctl and then a `okctl upgrade`:

```
~/Documents/okctl/h-eide-okctl-config [master] /Users/origo/Documents/okctl/okctl/cmd/okctl/okctl venv -c cluster/h-eide-dev/cluster.yaml
...


~/Documents/okctl/h-eide-okctl-config (h-eide-dev:default) $ /Users/origo/Documents/okctl/okctl/cmd/okctl/okctl upgrade
Found 2 applicable upgrade(s):
0.0.87.argocd, 0.0.92.rotate-argocd-ssh-key

preloading missing binary: okctl-upgrade_0.0.87.argocd (0.0.87.argocd)
preloading missing binary: okctl-upgrade_0.0.92.rotate-argocd-ssh-key (0.0.92.rotate-argocd-ssh-key)
Simulating upgrades (we're not doing any actual changes yet, just printing what's going to happen)...

--- Simulating upgrade: okctl-upgrade_0.0.87.argocd ---
Current chart version is v2.1.7. This upgrade only targets chart version 1.6.2, v1.6.2. Ignoring upgrade.
--- Simulating upgrade: okctl-upgrade_0.0.92.rotate-argocd-ssh-key ---
creating rotater: initializing: initializing okctl: acquiring Github authenticator: unable to create a keyring. It is possible no valid backends were found
on your system, take a look at this site for valid options:
https://github.com/99designs/keyring#keyring

On linux pass works well, for instance:
https://www.passwordstore.org/

Specified keyring backend not available
--- Upgrade failed: okctl-upgrade_0.0.92.rotate-argocd-ssh-key ---
Error: upgrading: running upgrade binaries: simulating upgrades: running upgrade binary okctl-upgrade_0.0.92.rotate-argocd-ssh-key: executing command: /var/folders/56/8f6jsj714x35twp23bvlzx740000gp/T/okctl2531595729/binaries/okctl-upgrade_0.0.92.rotate-argocd-ssh-key/0.0.92.rotate-argocd-ssh-key/Darwin/amd64/okctl-upgrade_0.0.92.rotate-argocd-ssh-key, got: exit status 1
```
- the `okctl-upgrade_0.0.87.argocd` upgrade passes, while the `okctl-upgrade_0.0.92.rotate-argocd-ssh-key` fails, this is correct behavior since we have only changed the `okctl-upgrade_0.0.87.argocd` upgrade 



<!--- Describe your changes in detail -->

## Motivation and Context
upgrades are not working on mac without this patch, it is critical to get out and working 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How to prove the effect of this PR?
See the above steps on the difference between CGO_ENABLED. Follow the steps in CGO_ENABLED=1 locally to reproduce this on your mac 

<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

## Additional info
Have not tested this on Linux, make sure to test!

<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
