### PR TITLE
KM588 🐛 Fix getting token when using SSO authentication

### DIFF
--- a/upgrades/0.0.88.activate-argo-app-sync-v2/pkg/kubectl/binary/helpers.go
+++ b/upgrades/0.0.88.activate-argo-app-sync-v2/pkg/kubectl/binary/helpers.go
@@ -74,6 +74,7 @@ func (c client) generateEnv() ([]string, error) {
 			constant.DefaultClusterKubeConfig,
 		),
 		"PATH": strings.Join(generatedPaths, ":"),
+		"HOME": homeDir,
 	})
 
 	env = append(env, awsEnvCredentials...)


### PR DESCRIPTION
Add HOME to environment variables when running kubectl.

## Description

When running kubectl, aws-iam-authenticator was unable to find the
AWS configuration files since HOME was not set in the subprocess.

## Motivation and Context

Fixes KM588

## How to prove the effect of this PR?

The v0.0.88 okctl upgrade should work when authenticating using AWS SSO.

## Additional info

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
