### PR TITLE
🐛 Fix upgrade breaking when applications dir does not exist

### DIFF
--- a/upgrades/0.0.99.seperate-ns-from-app/main.go
+++ b/upgrades/0.0.99.seperate-ns-from-app/main.go
@@ -66,7 +66,14 @@ func buildRootCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			return upgrade.Start(ctx, logger, fs, flags, cluster)
+			err := upgrade.Start(ctx, logger, fs, flags, cluster)
+			if errors.Is(err, commonerrors.ErrNothingToDo) {
+				logger.Debug("Nothing to do, ignoring upgrade")
+
+				return nil
+			}
+
+			return err
 		},
 	}
 

--- a/upgrades/0.0.99.seperate-ns-from-app/makefile
+++ b/upgrades/0.0.99.seperate-ns-from-app/makefile
@@ -40,3 +40,12 @@ lint: $(GOLANGCILINT)
 	$(GOLANGCILINT) run
 
 check: fmt lint test
+
+clean-upgrade:
+	find manual-tests -name 'upgrade' | xargs rm
+distribute-upgrade:
+	go build -o upgrade main.go
+	cp ./upgrade manual-tests/automatiskeprosesser-aws-infra/upgrade
+	cp ./upgrade manual-tests/helsedata-okctlcfg/upgrade
+	cp ./upgrade manual-tests/origo-booking-iac/upgrade
+	cp ./upgrade manual-tests/veiviser-infra/upgrade

--- a/upgrades/0.0.99.seperate-ns-from-app/makefile
+++ b/upgrades/0.0.99.seperate-ns-from-app/makefile
@@ -41,6 +41,8 @@ lint: $(GOLANGCILINT)
 
 check: fmt lint test
 
+# The following targets only works with some manual operations, i.e: creating a folder called "manual-tests", then clone
+# the relevant IAC repositories into the newly created folder. 
 clean-upgrade:
 	find manual-tests -name 'upgrade' | xargs rm
 distribute-upgrade:

--- a/upgrades/0.0.99.seperate-ns-from-app/pkg/lib/commonerrors/api.go
+++ b/upgrades/0.0.99.seperate-ns-from-app/pkg/lib/commonerrors/api.go
@@ -2,4 +2,7 @@ package commonerrors
 
 import "errors"
 
-var ErrUserAborted = errors.New("aborted by user")
+var (
+	ErrUserAborted = errors.New("aborted by user")
+	ErrNothingToDo = errors.New("nothing to do")
+)

--- a/upgrades/0.0.99.seperate-ns-from-app/pkg/upgrade/api.go
+++ b/upgrades/0.0.99.seperate-ns-from-app/pkg/upgrade/api.go
@@ -3,6 +3,9 @@ package upgrade
 import (
 	"context"
 	"fmt"
+	"path"
+
+	"github.com/oslokommune/okctl-upgrade/upgrades/0.0.99.seperate-ns-from-app/pkg/lib/commonerrors"
 
 	"github.com/oslokommune/okctl-upgrade/upgrades/0.0.99.seperate-ns-from-app/pkg/kubectl"
 
@@ -21,6 +24,13 @@ func Start(_ context.Context, logger logging.Logger, fs *afero.Afero, flags cmdf
 	absoluteRepositoryRootDir, err := paths.GetRepositoryRootDirectory()
 	if err != nil {
 		return fmt.Errorf("acquiring repository root dir: %w", err)
+	}
+
+	logger.Debug("Running preflight tests")
+
+	err = preflight(logger, fs, absoluteRepositoryRootDir, cluster)
+	if err != nil {
+		return fmt.Errorf("running preflight tests: %w", err)
 	}
 
 	logger.Debug("Enabling namespace synchronization")
@@ -48,6 +58,23 @@ func Start(_ context.Context, logger logging.Logger, fs *afero.Afero, flags cmdf
 	})
 	if err != nil {
 		return fmt.Errorf("migrating existing namespaces: %w", err)
+	}
+
+	return nil
+}
+
+func preflight(logger logging.Logger, fs *afero.Afero, absoluteRepositoryRootDir string, cluster v1alpha1.Cluster) error {
+	absoluteApplicationsDir := path.Join(absoluteRepositoryRootDir, cluster.Github.OutputPath, paths.ApplicationsDir)
+
+	hasApplicationsDir, err := fs.Exists(absoluteApplicationsDir)
+	if err != nil {
+		return fmt.Errorf("checking applications directory existence: %w", err)
+	}
+
+	if !hasApplicationsDir {
+		logger.Debug("No application directory found, ignoring upgrade")
+
+		return fmt.Errorf("no application directory found: %w", commonerrors.ErrNothingToDo)
 	}
 
 	return nil

--- a/upgrades/0.0.99.seperate-ns-from-app/pkg/upgrade/api_test.go
+++ b/upgrades/0.0.99.seperate-ns-from-app/pkg/upgrade/api_test.go
@@ -1,0 +1,56 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oslokommune/okctl-upgrade/upgrades/0.0.99.seperate-ns-from-app/pkg/lib/cmdflags"
+	"github.com/oslokommune/okctl-upgrade/upgrades/0.0.99.seperate-ns-from-app/pkg/lib/commonerrors"
+	"github.com/oslokommune/okctl-upgrade/upgrades/0.0.99.seperate-ns-from-app/pkg/lib/logging"
+	"github.com/oslokommune/okctl-upgrade/upgrades/0.0.99.seperate-ns-from-app/pkg/lib/manifest/apis/okctl.io/v1alpha1"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStart(t *testing.T) {
+	testCases := []struct {
+		name      string
+		withFs    *afero.Afero
+		expectErr error
+	}{
+		{
+			name: "Should do nothing upon missing applications folder",
+			withFs: func() *afero.Afero {
+				fs := &afero.Afero{Fs: afero.NewMemMapFs()}
+
+				_ = fs.MkdirAll("/infrastructure/mock-cluster-prod/argocd", 0o700)
+
+				return fs
+			}(),
+			expectErr: commonerrors.ErrNothingToDo,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cluster := v1alpha1.Cluster{
+				Metadata: v1alpha1.ClusterMeta{Name: "mock-cluster"},
+				Github:   v1alpha1.ClusterGithub{OutputPath: "infrastructure"},
+			}
+
+			flags := cmdflags.Flags{
+				Debug:   false,
+				DryRun:  false,
+				Confirm: true,
+			}
+
+			err := Start(context.Background(), logging.Logger{}, tc.withFs, flags, cluster)
+			assert.True(t, errors.Is(err, tc.expectErr))
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR introduces a check that ignores the upgrade when no
applications folder is found.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The upgrade 0.0.99 breaks when the IAC is missing an
    `/infrastructure/applications` directory.


## How to prove the effect of this PR?

<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->
1. Build the upgrade with `go build main.go`
2. `mv ./infrastructure/applications applications-backup` in the IAC repo root
3. `export OKCTL_CLUSTER_DECLARATION=<cluster.yaml path>`
4. Run the upgrade in the IAC root with `--debug true` and `--dry-run=false`
    and verify that there is no changes done either by reading the debug output
	or a git diff

## Additional info

<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
