### PR TITLE
22Q2-45 🐛 Don't halt execution on dry-run

### DIFF
--- a/upgrades/0.0.102.eks-1-21/main.go
+++ b/upgrades/0.0.102.eks-1-21/main.go
@@ -55,7 +55,7 @@ func buildRootCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
-			err := upgrade.Start(logger, kubectl.New())
+			err := upgrade.Start(logger, flags, kubectl.New())
 			if errors.Is(err, commonerrors.ErrNothingToDo) {
 				logger.Debug("Nothing to do, ignoring upgrade")
 

--- a/upgrades/0.0.102.eks-1-21/pkg/upgrade/api.go
+++ b/upgrades/0.0.102.eks-1-21/pkg/upgrade/api.go
@@ -2,6 +2,7 @@ package upgrade
 
 import (
 	"fmt"
+	"github.com/oslokommune/okctl-upgrade/upgrades/okctl-upgrade/upgrades/0.0.102.eks-1-21/pkg/lib/cmdflags"
 
 	"github.com/oslokommune/okctl-upgrade/upgrades/okctl-upgrade/upgrades/0.0.102.eks-1-21/pkg/kubectl"
 	"github.com/oslokommune/okctl-upgrade/upgrades/okctl-upgrade/upgrades/0.0.102.eks-1-21/pkg/lib/commonerrors"
@@ -10,7 +11,7 @@ import (
 
 const minimumEKSMinorVersion = 21
 
-func Start(logger logging.Logger, kubectl kubectl.Client) error {
+func Start(logger logging.Logger, flags cmdflags.Flags, kubectl kubectl.Client) error {
 	version, err := kubectl.GetVersion()
 	if err != nil {
 		return fmt.Errorf("running kubectl version: %w", err)
@@ -38,6 +39,10 @@ func Start(logger logging.Logger, kubectl kubectl.Client) error {
 	logger.Info("For more information, see https://www.okctl.io/eks-cluster-upgrades")
 	logger.Info("")
 
-	return fmt.Errorf("current EKS version is 1.%d, but must be at least 1.%d",
-		currentEKSMinorVersion, minimumEKSMinorVersion)
+	if flags.DryRun {
+		return nil
+	} else {
+		return fmt.Errorf("current EKS version is 1.%d, but must be at least 1.%d",
+			currentEKSMinorVersion, minimumEKSMinorVersion)
+	}
 }

--- a/upgrades/0.0.102.eks-1-21/pkg/upgrade/api_test.go
+++ b/upgrades/0.0.102.eks-1-21/pkg/upgrade/api_test.go
@@ -2,6 +2,7 @@ package upgrade_test
 
 import (
 	"github.com/oslokommune/okctl-upgrade/upgrades/okctl-upgrade/upgrades/0.0.102.eks-1-21/pkg/kubectl/version"
+	"github.com/oslokommune/okctl-upgrade/upgrades/okctl-upgrade/upgrades/0.0.102.eks-1-21/pkg/lib/cmdflags"
 	"testing"
 
 	"github.com/oslokommune/okctl-upgrade/upgrades/okctl-upgrade/upgrades/0.0.102.eks-1-21/pkg/kubectl"
@@ -31,9 +32,10 @@ func TestStart(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			kubectlClient := mockKubectlWithVersion(tc.version)
+			flags := cmdflags.Flags{}
 			logger := logging.New(logging.Debug)
 
-			err := upgrade.Start(logger, kubectlClient)
+			err := upgrade.Start(logger, flags, kubectlClient)
 
 			assert.Error(t, err)
 			assert.Containsf(t, err.Error(), tc.errorContains, "unexpected error message")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

When trying to run okctl upgrade, I got this:

```sh
$ okctl upgrade -c okctl-reference-dev.yaml
Found 3 applicable upgrade(s):
0.0.96.remote-state-versioning, 0.0.99.seperate-ns-from-app, 0.0.102.eks-1-21

preloading missing binary: okctl-upgrade_0.0.96.remote-state-versioning (0.0.96.remote-state-versioning)
preloading missing binary: okctl-upgrade_0.0.99.seperate-ns-from-app (0.0.99.seperate-ns-from-app)
preloading missing binary: okctl-upgrade_0.0.102.eks-1-21 (0.0.102.eks-1-21)
Simulating upgrades (we're not doing any actual changes yet, just printing what's going to happen)... 

--- Simulating upgrade: okctl-upgrade_0.0.96.remote-state-versioning ---
--- Simulating upgrade: okctl-upgrade_0.0.99.seperate-ns-from-app ---
--- Simulating upgrade: okctl-upgrade_0.0.102.eks-1-21 ---

❗ IMPORTANT

Current EKS version is: 1.20
You must upgrade EKS to version 1.21 by following this guide: https://github.com/oslokommune/okctl-upgrade/tree/main/gists/bump-eks

For more information, see https://www.okctl.io/eks-cluster-upgrades

current EKS version is 1.20, but must be at least 1.21
--- Upgrade failed: okctl-upgrade_0.0.102.eks-1-21 ---
Error: upgrading: running upgrade binaries: simulating upgrades: running upgrade binary okctl-upgrade_0.0.102.eks-1-21: executing command: /tmp/okctl1817545297/binaries/okctl-upgrade_0.0.102.eks-1-21/0.0.102.eks-1-21/Linux/amd64/okctl-upgrade_0.0.102.eks-1-21, got: exit status 1
[
```

Problem: okctl upgrade didn't run upgrades for 0.0.96 and 0.0.99. We never got to the step where the user can press "Y" to run the actual upgrades.

Cause: 0.0.102 returned an error, which aborted the whole upgrade process in Okctl.

Solution: Only return an error when running with dry-run=false. It will give a bit misleading dry-run upgrade, as it will show upgrades after 0.0.102 being run in dry run mode, but when running with dry-run=false, those upgrades won't be run because 0.0.102 returned an error. But that is acceptable. Fixing this requires a redesign of how upgrades are run, and that is not something we should prioritize in Okctl now I think.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Let users be able to run upgrades up and to 0.0.102. It's possible to do with downgrading okctl to 0.0.101, but that is not obvious, and I don't want to have to explain that in the docs and on Slack.

## How to prove the effect of this PR?

<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

See https://github.com/oslokommune/okctl-upgrade/blob/main/README.md#test-the-upgrade.

## Additional info

<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
