### PR TITLE
🐛 Add missing AWS_REGION

### DIFF
--- a/gists/helm-component-extraction/argocd/Makefile
+++ b/gists/helm-component-extraction/argocd/Makefile
@@ -100,6 +100,7 @@ namespace.yaml:
 
 values.yaml: argocd-data argocd-data-test
 	cat templates/values.yaml | \
+		AWS_REGION=$(AWS_REGION) \
 		CLUSTER_NAME=$(CLUSTER_NAME) \
 		ISSUER_URL=$(ISSUER_URL) \
 		CLIENT_ID=$(CLIENT_ID) \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`make values.yaml` creates a file with the contents. on line 418:

```yaml
issuer: https://cognito-idp..amazonaws.com/eu-west-1_XXXXXXXXXXX
```

It should be

```yaml
issuer: https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_XXXXXXXXXXX
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[KCI-9](https://github.com/oslokommune/kjoremiljo-confidential-issues/issues/9)

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

```sh
unset AWS_REGION
cd infrastructure/ykctl/helm-components/argocd
make values.yaml
```

Verify that 418 looks like in the example above.

Then apply this PR, run above commands again, and see that the region is inserted.

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
