### PR TITLE
KCI-9 ✅ Add datasource configuration to Loki

### DIFF
--- a/gists/helm-component-extraction/loki/Makefile
+++ b/gists/helm-component-extraction/loki/Makefile
@@ -9,7 +9,13 @@ CLUSTER_NAME?=
 ## User input END           ##
 ##############################
 
-configure:
+datasource.yaml:
+	cp templates/datasource.yaml .
+
+install-datasource:
+	kubectl apply -f datasource.yaml
+
+configure: datasource.yaml
 	@test -n "$(AWS_PROFILE)" || (echo "Missing AWS_PROFILE environment variable. export AWS_PROFILE with the relevant profile" && exit 1)
 	@test -n "$(CLUSTER_NAME)" || (echo "Missing CLUSTER_NAME value. Edit the Makefile and configure the user input" && exit 1)
 	cat templates/values.yaml | \
@@ -17,7 +23,7 @@ configure:
 		AWS_REGION=$$(aws configure get region) \
 		envsubst > values.yaml
 
-install:
+install: install-datasource
 	@test -f values.yaml || (echo "Missing values.yaml file. Run 'make configure' first" && exit 1)
 	yq \
 		'.spec.source.helm.values = load_str("values.yaml")' \

--- a/gists/helm-component-extraction/loki/templates/datasource.yaml
+++ b/gists/helm-component-extraction/loki/templates/datasource.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: loki-datasource
+  namespace: monitoring
+  labels:
+    grafana_datasource: "1"
+
+data:
+  loki-datasource.yaml: |
+    apiVersion: 1
+    datasources:
+    - access: proxy
+      basicAuth: false
+      editable: false
+      jsonData:
+        tlsSkipVerify: true
+      name: Loki
+      orgId: 1
+      type: loki
+      url: http://loki:3100
+      version: 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Adds missing datasource configuration for Loki in Grafana

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Without it, Loki is not available as a datasource in Grafana

## How to prove the effect of this PR?
<!--- Please describe in detail how verify the change you have done. -->
<!--- In the context of a bug fix, this should include how to reproduce the bug. -->
<!--- In the context of a feature, this should include how to demonstrate the feature. -->
<!--- In the event of a pure code refactoring, just ignore this section -->

### If Loki is already installed

1. Run `make datasource.yaml` to generate the datasource config
2. Run `make install-datasource` to install it to your cluster
3. Open Grafana and verify that Loki is available as a datasource in Explore -> Upper left corner dropdown list that says
    Prometheus

## Additional info
<!--- Ignore if not relevant -->
<!--- For example screenshots -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
